### PR TITLE
Add per epoch tensorboard metrics

### DIFF
--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -606,7 +606,7 @@ def train():
             # save summary of loss this epoch
             epoch_loss = session.run(
                 epoch_summary, 
-                feed_dict={'per_epoch_loss': mean_loss}
+                feed_dict={'per_epoch_loss:0': mean_loss}
             )
 
             summary_writer.add_summary(epoch_loss, epoch)

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -599,7 +599,7 @@ def train():
             pbar.finish()
             mean_loss = total_loss / step_count if step_count > 0 else 0.0
 
-            epoch_summary = tfv1.summary.scalar(name='epoch_loss', tensor=mean_loss, collections=['epoch_summaries'])
+            epoch_summary = tfv1.summary.scalar(name='epoch_loss', tensor=tf.constant(mean_loss), collections=['epoch_summaries'])
             summary_writer.add_summary(epoch_summary, epoch)
 
             return mean_loss, step_count

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -495,13 +495,6 @@ def train():
 
     epoch_loss = variable_on_cpu('per_epoch_loss', [], tfv1.zeros_initializer())
     epoch_summary = tfv1.summary.scalar(name='epoch_loss', tensor=epoch_loss, collections=['epoch_summaries'])
-    # epoch_summaries_op = tfv1.summary.merge_all('epoch_summaries')
-
-    # step_summary_writers = {
-    #     'train': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'train'), max_queue=120),
-    #     'dev': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'dev'), max_queue=120),
-    #     'metrics': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'metrics'), max_queue=120),
-    # }
 
     summary_writers = {
         'train': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'train'), max_queue=120),

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -490,12 +490,12 @@ def train():
     global_step = tfv1.train.get_or_create_global_step()
     apply_gradient_op = optimizer.apply_gradients(avg_tower_gradients, global_step=global_step)
 
-    def update_epoch_loss(epoch_loss):
-        return tfv1.summary.scalar(name='epoch_loss', tensor=epoch_loss, collections=['epoch_summaries'])
-
     # Summaries
     step_summaries_op = tfv1.summary.merge_all('step_summaries')
-    epoch_summaries_op = tfv1.summary.merge_all('epoch_summaries')
+
+    epoch_loss = variable_on_cpu('per_epoch_loss', [1], tfv1.zeros_initializer())
+    epoch_summary = tfv1.summary.scalar(name='epoch_loss', tensor=epoch_loss, collections=['epoch_summaries'])
+    # epoch_summaries_op = tfv1.summary.merge_all('epoch_summaries')
 
     # step_summary_writers = {
     #     'train': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'train'), max_queue=120),
@@ -603,7 +603,12 @@ def train():
             pbar.finish()
             mean_loss = total_loss / step_count if step_count > 0 else 0.0
 
-            epoch_loss = update_epoch_loss(mean_loss)
+            # save summary of loss this epoch
+            epoch_loss = session.run(
+                epoch_summary, 
+                feed_dict={'per_epoch_loss': mean_loss}
+            )
+
             summary_writer.add_summary(epoch_loss, epoch)
 
             return mean_loss, step_count

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -490,8 +490,12 @@ def train():
     global_step = tfv1.train.get_or_create_global_step()
     apply_gradient_op = optimizer.apply_gradients(avg_tower_gradients, global_step=global_step)
 
+    def update_epoch_loss(epoch_loss):
+        return tfv1.summary.scalar(name='epoch_loss', tensor=epoch_loss, collections=['epoch_summaries'])
+
     # Summaries
     step_summaries_op = tfv1.summary.merge_all('step_summaries')
+    epoch_summaries_op = tfv1.summary.merge_all('epoch_summaries')
 
     # step_summary_writers = {
     #     'train': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'train'), max_queue=120),
@@ -599,8 +603,8 @@ def train():
             pbar.finish()
             mean_loss = total_loss / step_count if step_count > 0 else 0.0
 
-            epoch_summary = tfv1.summary.scalar(name='epoch_loss', tensor=tf.constant(mean_loss), collections=['epoch_summaries'])
-            summary_writer.add_summary(epoch_summary, epoch)
+            epoch_loss = update_epoch_loss(mean_loss)
+            summary_writer.add_summary(epoch_loss, epoch)
 
             return mean_loss, step_count
 

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -493,7 +493,7 @@ def train():
     # Summaries
     step_summaries_op = tfv1.summary.merge_all('step_summaries')
 
-    epoch_loss = variable_on_cpu('per_epoch_loss', [1], tfv1.zeros_initializer())
+    epoch_loss = variable_on_cpu('per_epoch_loss', [], tfv1.zeros_initializer())
     epoch_summary = tfv1.summary.scalar(name='epoch_loss', tensor=epoch_loss, collections=['epoch_summaries'])
     # epoch_summaries_op = tfv1.summary.merge_all('epoch_summaries')
 

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -988,3 +988,5 @@ def run_script():
 
 if __name__ == '__main__':
     run_script()
+
+    

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -492,7 +492,14 @@ def train():
 
     # Summaries
     step_summaries_op = tfv1.summary.merge_all('step_summaries')
-    step_summary_writers = {
+
+    # step_summary_writers = {
+    #     'train': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'train'), max_queue=120),
+    #     'dev': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'dev'), max_queue=120),
+    #     'metrics': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'metrics'), max_queue=120),
+    # }
+
+    summary_writers = {
         'train': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'train'), max_queue=120),
         'dev': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'dev'), max_queue=120),
         'metrics': tfv1.summary.FileWriter(os.path.join(FLAGS.summary_dir, 'metrics'), max_queue=120),
@@ -534,7 +541,7 @@ def train():
             total_loss = 0.0
             step_count = 0
 
-            step_summary_writer = step_summary_writers.get(set_name)
+            summary_writer = summary_writers.get(set_name)
             checkpoint_time = time.time()
 
             if is_train and FLAGS.cache_for_epochs > 0 and FLAGS.feature_cache:
@@ -583,7 +590,7 @@ def train():
 
                 pbar.update(step_count)
 
-                step_summary_writer.add_summary(step_summary, current_step)
+                summary_writer.add_summary(step_summary, current_step)
 
                 if is_train and FLAGS.checkpoint_secs > 0 and time.time() - checkpoint_time > FLAGS.checkpoint_secs:
                     checkpoint_saver.save(session, checkpoint_path, global_step=current_step)
@@ -591,6 +598,10 @@ def train():
 
             pbar.finish()
             mean_loss = total_loss / step_count if step_count > 0 else 0.0
+
+            epoch_summary = tfv1.summary.scalar(name='epoch_loss', tensor=mean_loss, collections=['epoch_summaries'])
+            summary_writer.add_summary(epoch_summary, epoch)
+
             return mean_loss, step_count
 
         log_info('STARTING Optimization')


### PR DESCRIPTION
This adds a summary to the Tensorboard, which records per-epoch losses. This allows for more accurate monitoring during training (and by extension, more informed hyperparameter choices down the road).